### PR TITLE
Update Cargo.toml add repository link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "Flatboat is a CLI tool that integrates Docker and Kubernetes tool
 authors = ["Juan Camilo Sánchez Urrego @JuanCSUCoder <juancsucoder@gmail.com>"]
 license = "AGPL-3.0-only"
 readme = "README.md"
+repository = "https://github.com/JuanCSUCoder/flatboat-cli"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
to allow Crates.io, lib.rs and rust-digger to link to it